### PR TITLE
Bugfix: mounting user bash configs caused read-only mount

### DIFF
--- a/scripts/run_dev/run_dev.py
+++ b/scripts/run_dev/run_dev.py
@@ -214,11 +214,6 @@ def get_docker_args(platform):
         "-v /tmp/.X11-unix:/tmp/.X11-unix",
         f"-v {shlex.quote(home_path)}/.Xauthority:/home/admin/.Xauthority:rw",
     ]
-    # Add existing bash config files
-    for config in get_existing_bash_configs():
-        docker_args.append(
-            f"-v {shlex.quote(home_path)}/{config}:/home/admin/{config}:ro"
-        )
     docker_args.extend([
         "-e DISPLAY",
         "-e NVIDIA_VISIBLE_DEVICES=all",


### PR DESCRIPTION
When running `isaac-ros activate` I got the following errors in `docker/scripts/workspace-entrypoint.sh`:

```
Creating non-root container 'admin' for host user uid=1000:gid=1000
cp: cannot create regular file '/home/admin/.bashrc': Read-only file system
cp: cannot create regular file '/home/admin/.profile': Read-only file system
chown: changing ownership of '/home/admin/.bashrc': Read-only file system
chown: changing ownership of '/home/admin/.profile': Read-only file system
```

This error arises because `docker run -v ~/.bashrc:/home/admin/.bashrc` cause the `/home/admin` folder to be mounted in read-only mode.

Moreover, mounting the bash configs inside the container could have all kinds of unwanted side effects, as the setup inside the container might be very different from that within the host system.